### PR TITLE
Fix syntax check fails even though a hidden syntax exists

### DIFF
--- a/st_package_reviewer/check/file/check_resource_files.py
+++ b/st_package_reviewer/check/file/check_resource_files.py
@@ -58,7 +58,10 @@ class CheckHasSublimeSyntax(FileChecker):
         syntax_files = self.glob("**/*.sublime-syntax")
 
         for path in syntax_files:
-            if not path.with_suffix(".tmLanguage").is_file():
+            if (
+                not path.with_suffix(".tmLanguage").is_file() and
+                not path.with_suffix(".hidden-tmLanguage").is_file()
+            ):
                 with self.file_context(path):
                     self.warn("'.sublime-syntax' support has been added in build 3092 and there "
                               "is no '.tmLanguage' fallback file")


### PR DESCRIPTION
The syntax checker checks all new syntax format files have a fallback
syntax for older versions otherwise it fails with the message e.g:

    Set "sublime_text": ">=3092" in your "releases" since the package contains a .sublime-syntax file
    File: res/Command-line mode.sublime-syntax

Re: https://github.com/wbond/package_control_channel/pull/6265#issuecomment-305319313