### PR TITLE
Fix some flake8 coding style issues

### DIFF
--- a/st_package_reviewer/__init__.py
+++ b/st_package_reviewer/__init__.py
@@ -1,5 +1,4 @@
-"""Review Sublime Text packages.
-"""
+"""Review Sublime Text packages."""
 
 __version__ = "0.2.2"
 

--- a/st_package_reviewer/__main__.py
+++ b/st_package_reviewer/__main__.py
@@ -40,7 +40,8 @@ def _prepare_nargs(nargs):
 
 
 def main():
-    """\
+    """Main.
+
     Return values:
         0: No errors
         -1: Invalid command line arguments
@@ -54,7 +55,6 @@ def main():
         Enter package paths or repository URLS continuously.
         Type `c` to copy the last report to your clipboard.
     """
-
     parser = argparse.ArgumentParser(prog=__package__,
                                      description="Check a Sublime Text package for common errors.",
                                      epilog=textwrap.dedent(main.__doc__),

--- a/tests/test_file_checkers.py
+++ b/tests/test_file_checkers.py
@@ -83,7 +83,6 @@ def test_reviewer_integration(package_path, check_runner):
     If all failures or warnings should be compared,
     specify them in "all_failures" and "all_warnings".
     """
-
     # Run checks first and report them to stdout,
     # so we have something to inspect when the test fails.
     check_runner.run(package_path)
@@ -99,8 +98,12 @@ def test_reviewer_integration(package_path, check_runner):
     assert not (warning_asserts and all_warning_asserts), \
         "Only one warnings meta file is allowed"
 
-    assert_none = not (failure_asserts or all_failure_asserts
-                       or warning_asserts or all_warning_asserts)
+    assert_none = not (
+        failure_asserts or
+        all_failure_asserts or
+        warning_asserts or
+        all_warning_asserts
+    )
 
     failures = {CheckAssert(failure.message, failure.details)
                 for failure in check_runner.failures}

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,13 @@ exclude =
   tests/packages,
   semver.py,
 max-line-length=100
+# D100  Missing docstring in public module
+# D101  Missing docstring in public class
+# D102  Missing docstring in public method
+# D103  Missing docstring in public function
+# D104  Missing docstring in public package
+# D105  Missing docstring in magic method
+ignore = D100, D101, D102, D103, D104, D105
 
 [coverage:run]
 # branch = True


### PR DESCRIPTION
This adds ignore rules for several specific docstring warnings in the
form of D*.  Those warnings tend to create a lot of flake8 noise.

Several other warnings have been fixed.