### PR TITLE
Added "primary" to keymap.

### DIFF
--- a/st_package_reviewer/check/file/check_keymaps.py
+++ b/st_package_reviewer/check/file/check_keymaps.py
@@ -145,7 +145,7 @@ class KeyMapping:
 
     @classmethod
     def _verify_and_normalize_chords(cls, chords):
-        modifiers = ("ctrl", "super", "alt", "shift")
+        modifiers = ("ctrl", "super", "alt", "shift", "primary")
 
         if not chords or not isinstance(chords, list):
             raise KeyMappingError("'keys' key is empty or not a list")

--- a/tests/packages/Keymaps/Default.sublime-keymap
+++ b/tests/packages/Keymaps/Default.sublime-keymap
@@ -28,5 +28,6 @@
   // invalid key in multi-chord
   { "keys": ["ctrl+k", "nope"], "command": "noop" },
   // valid key binding
-  { "keys": ["super+ctrl+alt+shift++"], "command": "noop" }
+  { "keys": ["super+ctrl+alt+shift++"], "command": "noop" },
+  { "keys": ["primary+shift+1"], "command": "noop" },
 ]


### PR DESCRIPTION
See #7.

Prevents a spurious error when the `primary` modifier key is used in a keymap.

Does *not* implement platform-specific default keymap checks.