### PR TITLE
Require a context for "<character>" bindings

### DIFF
--- a/st_package_reviewer/check/file/check_keymaps.py
+++ b/st_package_reviewer/check/file/check_keymaps.py
@@ -86,6 +86,12 @@ class CheckKeymaps(FileChecker):
                     self.warn("Binding defines supplementary keys {}".format(supplementary_keys))
 
                 if 'keys' in binding:
+                    if binding['keys'] == ["<character>"]:
+                        if not binding.get('context'):
+                            self.fail("'<character>' bindings must have a 'context'")
+                            idx_to_del.add(i)
+                        continue
+
                     try:
                         norm_chords = k_map._verify_and_normalize_chords(binding['keys'])
                     except KeyMappingError as e:

--- a/tests/packages/Keymaps/Default.sublime-keymap
+++ b/tests/packages/Keymaps/Default.sublime-keymap
@@ -30,4 +30,12 @@
   // valid key binding
   { "keys": ["super+ctrl+alt+shift++"], "command": "noop" },
   { "keys": ["primary+shift+1"], "command": "noop" },
+
+  // <character> bindings must have a context
+  { "keys": ["<character>"], "command": "noop" },
+  { "keys": ["<character>"], "command": "noop",
+    "context": [
+      { "key": "setting.auto_indent" },
+    ]
+   },
 ]

--- a/tests/packages/Keymaps/all_failures
+++ b/tests/packages/Keymaps/all_failures
@@ -21,6 +21,9 @@
     File: Default (OSX).sublime-keymap
 - The binding ['super+alt+s'] unconditionally overrides a default binding
     File: Default (OSX).sublime-keymap
+- '<character>' bindings must have a 'context'
+    File: Default.sublime-keymap
+    Binding: {"command": "noop", "keys": ["<character>"]}
 - Invalid key 'Ü'
     File: Default.sublime-keymap
     Binding: {"command": "hurf_durf", "keys": ["ctrl+\u00dc"]}


### PR DESCRIPTION
Closes #16.

Not the most sophisticated solution, but it does the job.