### PR TITLE
recognise "unlicense" LICENSE files

### DIFF
--- a/st_package_reviewer/check/file/check_license.py
+++ b/st_package_reviewer/check/file/check_license.py
@@ -8,7 +8,7 @@ class CheckLicense(FileChecker):
     def check(self):
         has_license = any(
             True for p in self.base_path.iterdir()
-            if re.search(r'(?i)^license', p.name)
+            if re.search(r'(?i)^(un)?license', p.name)
         )
 
         if not has_license:


### PR DESCRIPTION
Recognises the [unlicense](https://unlicense.org) type of license file. GitHub already supports this as well.

> You would traditionally put the above statement into a file named COPYING or LICENSE. However, to explicitly distance yourself from the whole concept of copyright licensing, we recommend that you put your unlicensing statement in a file named UNLICENSE

(originally: https://github.com/wbond/packagecontrol.io/pull/127)